### PR TITLE
Updating grunt-contrib-copy to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-ejs-static": "^0.4.3",
     "grunt-rewrite": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.7.0",
-    "grunt-contrib-copy": "^0.8.2",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-ejs-static": "^0.4.3",
     "grunt-rewrite": "^1.0.1",
     "grunt-shell": "^1.1.2"


### PR DESCRIPTION
Please update [grunt-contrib-copy](https://npmjs.org/package/grunt-contrib-copy) to version 1.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`85150c7`](https://github.com/gruntjs/grunt-contrib-copy/commit/85150c7bfef1279911cb844eefdcd7b2c31ad9d1) `v1.0.0`
- [`ee90273`](https://github.com/gruntjs/grunt-contrib-copy/commit/ee9027346f1bbd21424d828deab17b86fddffe8b) `Merge pull request #271 from gruntjs/dev`
- [`16b2852`](https://github.com/gruntjs/grunt-contrib-copy/commit/16b2852b52f8e908eb7198c2fa96a6d6eb811ecc) `Bump devDependencies.`
- [`829032d`](https://github.com/gruntjs/grunt-contrib-copy/commit/829032d5ed26b47b872bc5df8b29d6cce500820d) `Merge pull request #268 from nalajcie/master`
- [`147a84b`](https://github.com/gruntjs/grunt-contrib-copy/commit/147a84bb2c583eefeea09ca6a278002bc81a20a8) `tests: disable testing timestamp equity under windows`
- [`217819f`](https://github.com/gruntjs/grunt-contrib-copy/commit/217819f9625b19589c417905faf8532aa479e083) `fix syncing utimes when copying files`
- [`ade2465`](https://github.com/gruntjs/grunt-contrib-copy/commit/ade24651db08637f88acbf8bd441281e5dc0a4e7) `Merge pull request #258 from ricog/patch-1`
- [`3a95e08`](https://github.com/gruntjs/grunt-contrib-copy/commit/3a95e0828e46e17616b2ff229c64e2c9f90c43d2) `Add example of using relative path`
- [`053e169`](https://github.com/gruntjs/grunt-contrib-copy/commit/053e169efa18120c7cf5566d3fb968fef41572f4) `Merge pull request #259 from ricog/patch-2`
- [`53d78fa`](https://github.com/gruntjs/grunt-contrib-copy/commit/53d78fa47aa8d55504ddca5dee17345bb8fb7567) `Specify expand: true for single file tree example`
- [`746495a`](https://github.com/gruntjs/grunt-contrib-copy/commit/746495aa5e268d28a76a4d57c6bb29c6477194c5) `add appveyor`
- [`e950787`](https://github.com/gruntjs/grunt-contrib-copy/commit/e950787bb326dc7a844776cabf976139f1a61843) `Update CI configs`
- [`1ecb72c`](https://github.com/gruntjs/grunt-contrib-copy/commit/1ecb72cd60a661ed91f4c90f671ca4d430ecd586) `Merge branch 'master' of github.com:gruntjs/grunt-contrib-copy`
- [`33363b4`](https://github.com/gruntjs/grunt-contrib-copy/commit/33363b47ba3249a4a8968a756e9ba442b039447e) `Point main to task`
- [`9549ec2`](https://github.com/gruntjs/grunt-contrib-copy/commit/9549ec2c7b6edd7ff182953309967b5b47cd0adc) `Remove peerDeps. Ref gruntjs/grunt#1116`

See the full [change log](https://github.com/gruntjs/grunt-contrib-copy/compare/018be2d7c7f7733858dc7094fbdf562ec25eb48d...85150c7bfef1279911cb844eefdcd7b2c31ad9d1) for everything that changed in this release.

<hr />

Please update [grunt-contrib-clean](https://npmjs.org/package/grunt-contrib-clean) to version 1.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`af10401`](https://github.com/gruntjs/grunt-contrib-clean/commit/af104010d9e35bc53635cd0bdec16791e009e530) `v1.0.0`
- [`856e582`](https://github.com/gruntjs/grunt-contrib-clean/commit/856e582444e95ca37c784f70a11a36cfc2f0f6a7) `Update changelog`
- [`c7f3ff5`](https://github.com/gruntjs/grunt-contrib-clean/commit/c7f3ff5585554b5c8ea192476bb386c1cf65fbe8) `Add grunt >= 0.4.5 peerDep`
- [`1e6bd9e`](https://github.com/gruntjs/grunt-contrib-clean/commit/1e6bd9eccc86fbc77c8c24add0d878560eb5b850) `Merge pull request #83 from JKAussieSkater/master`
- [`95772d9`](https://github.com/gruntjs/grunt-contrib-clean/commit/95772d9102e504dfd1d169f5de5d3c3b1968fc7c) `- Minor: Corrected typo "acheive" to "achieve"`
- [`dd47c86`](https://github.com/gruntjs/grunt-contrib-clean/commit/dd47c8655aced5f82becde1415d3b16463549d78) `Update CI configs`
- [`dc239f1`](https://github.com/gruntjs/grunt-contrib-clean/commit/dc239f1c7663500140cc5b69be367ea94fc898b8) `Merge pull request #82 from elgubenis/patch-1`
- [`1a20629`](https://github.com/gruntjs/grunt-contrib-clean/commit/1a20629d38e9f5a97924b0d67d4052b5c9b7d6df) `Update deps`
- [`a76f6b0`](https://github.com/gruntjs/grunt-contrib-clean/commit/a76f6b0ddb72306979cc8ad2100aec9a0cb92686) `Point main to task`
- [`e137b12`](https://github.com/gruntjs/grunt-contrib-clean/commit/e137b1277310cc6e75f0193cfbb950a88fbda365) `Remove peerDeps. Ref gruntjs/grunt#1116`
- [`05b4c22`](https://github.com/gruntjs/grunt-contrib-clean/commit/05b4c22ece7b38821223c2deabdb11c9013027be) `Added brief explanation of globbing behaviour patt&hellip;`
- [`c77e0a0`](https://github.com/gruntjs/grunt-contrib-clean/commit/c77e0a0b305ec642d764d111089684a0eb2d10aa) `Documented examples for using `no-write``
- [`b59c4cc`](https://github.com/gruntjs/grunt-contrib-clean/commit/b59c4ccc5cef5ba67b4d1fc428f3471ce90f7475) `Added important note: `no-write` contains a hyphen&hellip;`
- [`8e1e617`](https://github.com/gruntjs/grunt-contrib-clean/commit/8e1e61756e7578e8a4fe2b29a186e26e77d4892d) `Clarified that log messages only appear in "--verb&hellip;`
- [`4913197`](https://github.com/gruntjs/grunt-contrib-clean/commit/4913197c8b9c09335bbec85ce683a11c3920a011) `Update copyright to 2016`

See the full [change log](https://github.com/gruntjs/grunt-contrib-clean/compare/fad22340cb9bcde44acf9841a437d20a78f4f038...af104010d9e35bc53635cd0bdec16791e009e530) for everything that changed in this release.
